### PR TITLE
use all attributes defined in implementation

### DIFF
--- a/charsleft_widget/widgets.py
+++ b/charsleft_widget/widgets.py
@@ -28,8 +28,9 @@ class CharsLeftInput(forms.TextInput, MediaMixin):
     def render(self, name, value, attrs=None):
         if value is None:
             value = ''
-        extra_attrs = {'type': self.input_type, 'name': name,
-                       'maxlength': self.attrs.get('maxlength')}
+        extra_attrs = {'type': self.input_type, 'name': name}
+        extra_attrs.update(self.attrs)
+        
         final_attrs = self.build_attrs(attrs, extra_attrs=extra_attrs)
         if value != '':
             final_attrs['value'] = force_str(self._format_value(value))


### PR DESCRIPTION
Before I fixed this, it clobbered the `size` attribute I had defined:

        widgets = {
            'title': CharsLeftInput(attrs={'size': 80}),
        }